### PR TITLE
Move /tmp into ram to reduce disk writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and analyzing and analysis. A Redis container is used to coordinate the tasks.
 ## Here's what you're gonna do
 - Go into the BirdNET-Analyzer directory. Do what it says there to get a BirdNET-Analyzer server running.
 - Assuming you are using docker-compose, create a new directory on your server for the application. Put the docker-compose.yml
-file from this repo in there. Create tmp, detections, and db directories in there as well.
+file from this repo in there. Create detections and db directories in there as well.
 - Edit the docker-compose.yml file to meet your needs.
     - If you just want to view the UI from your intranet via IP addresses,
 all you should have to do is replace 192.168.1.75 (in 3 places) with the IP address of your server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,10 @@ services:
       CORS_ORIGINS: http://192.168.1.75:7008
       REDIS_SERVER: redis
       REDIS_PORT: 6379
+    tmpfs:
+      - /tmp:size=16M
+      - /var/log
     volumes:
-      - "./tmp:/tmp"
       - "./detections:/detections"
       - "./db:/db"
       - "/etc/localtime:/etc/localtime:ro"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
       REDIS_PORT: 6379
     tmpfs:
       - /tmp:size=16M
-      - /var/log
     volumes:
       - "./detections:/detections"
       - "./db:/db"


### PR DESCRIPTION
As discussed in #5, suggest moving the `/tmp` writes into ram as they are unnecessarily writing to disk. Commit is allocating 16mb of space which can probably be even cut further as my `tmp` folder within the container only ever held around 2mb.