### PR TITLE
Keep Best Recordings

### DIFF
--- a/birdcage_backend/app/recordingcleanup.py
+++ b/birdcage_backend/app/recordingcleanup.py
@@ -23,7 +23,7 @@ def recordingcleanup(numdays):
     cursor = conn.cursor()
 
     # Retrieve records older than numdays
-    cursor.execute("SELECT id, filename FROM detections WHERE timestamp < ? AND LENGTH(filename) > 0", (timestamp_limit,))
+    cursor.execute("SELECT id, filename FROM detections WHERE timestamp < ? AND LENGTH(filename) > 0 AND (id, filename) NOT IN (SELECT id, filename FROM (SELECT id, filename, max(confidence) FROM detections WHERE LENGTH(filename)> 0 GROUP BY scientific_name))", (timestamp_limit,))
     records = cursor.fetchall()
 
     # Iterate through records


### PR DESCRIPTION
Commit adds a check that prevents the best existing recording from being deleted. Since it's only one recording per scientific_name, should not add much overhead and adds ability to view later.