### PR TITLE
center detection common name

### DIFF
--- a/birdcage_frontend/templates/detection_details.html
+++ b/birdcage_frontend/templates/detection_details.html
@@ -9,9 +9,10 @@
         <div class="col-2">
             <button id="back-btn" class="btn btn-secondary">Go Back</button>
         </div>
-        <div class="col-10 text-center">
+        <div class="col-8 text-center">
             <h1 class="my-4 d-inline-block mx-auto"><span id="detection-common-name"></span></h1>
         </div>
+        <div class="col-2"></div> 
     </div>
 
     <div class="row">


### PR DESCRIPTION
Cosmetic change to the `detection_details.html` to properly center the common name across the page. It was slightly shifted to the right.