### PR TITLE
Add missing url prefix on reports

### DIFF
--- a/birdcage_frontend/templates/annual_report.html
+++ b/birdcage_frontend/templates/annual_report.html
@@ -185,7 +185,7 @@ Annual Report
             defaultDate: "{{ year }}",
             onChange: function (selectedDates, dateStr, instance) {
                 if (selectedDates.length > 0) {
-                    const newUrl = `/annual_report/${dateStr}`;
+                    const newUrl = `{{ script_name }}/annual_report/${dateStr}`;
                     window.location.href = newUrl;
                 }
             }

--- a/birdcage_frontend/templates/monthly_report.html
+++ b/birdcage_frontend/templates/monthly_report.html
@@ -167,7 +167,7 @@ Monthly Report
             defaultDate: "{{ month }}",
             onChange: function (selectedDates, dateStr, instance) {
                 if (selectedDates.length > 0) {
-                    const newUrl = `/monthly_report/${dateStr}`;
+                    const newUrl = `{{ script_name }}/monthly_report/${dateStr}`;
                     window.location.href = newUrl;
                 }
             }


### PR DESCRIPTION
Missed a couple of url prefixes in the reporting UI.