### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,14 @@ services:
       - "7667:8080"
 
   redis:
+    restart: unless-stopped
     image: "redis:latest" #the redis server doesn't need to be exposed outside the virtual network, so no "ports"
                           #mapping is needed
     networks:
       - birdcage_net
 
   birdcage_backend:
+    restart: unless-stopped
     image: "mmcc73/birdcage_backend:latest"
     ports:
       - "7007:7007"
@@ -58,6 +60,7 @@ services:
       - birdcage_net
 
   birdcage_frontend:
+    restart: unless-stopped
     image: "mmcc73/birdcage_frontend:latest"
     ports:
       - "7008:7008"


### PR DESCRIPTION
Upon a reboot or a restart of docker I noticed that the containers for redis,birdcage_frontend, and birdcage_backend will be stopped, however, birdnetserver will be running. I can start them manually and everything works as it should. Adding "restart: unless-stopped" under each container in the docker compose file seems to resolve this issue.