### PR TITLE
Backend stability work for rtsp streams

### DIFF
--- a/birdcage_backend/Dockerfile
+++ b/birdcage_backend/Dockerfile
@@ -2,7 +2,8 @@
 FROM python:3.10
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y ffmpeg pulseaudio
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y ffmpeg pulseaudio && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp
 

--- a/birdcage_backend/app/stream_processing.py
+++ b/birdcage_backend/app/stream_processing.py
@@ -69,8 +69,8 @@ def record_stream_ffmpeg(stream_url, protocol, transport, seconds, output_filena
         if protocol == 'rtsp':
             (
                 ffmpeg
-                    .input(stream_url, rtsp_transport=transport.lower())
-                    .output(output_filename, format='wav', t=seconds, loglevel='warning',
+                    .input(stream_url, rtsp_transport=transport.lower(), t=seconds)
+                    .output(output_filename, format='wav', loglevel='warning',
                             ac=1, ar=48000, sample_fmt='s16')
                     .run(capture_stdout=True, capture_stderr=True)
             )
@@ -78,8 +78,8 @@ def record_stream_ffmpeg(stream_url, protocol, transport, seconds, output_filena
         elif protocol == 'pulse':
             (
                 ffmpeg
-                    .input(stream_url, f='pulse')
-                    .output(output_filename, format='wav', t=seconds, loglevel='warning',
+                    .input(stream_url, f='pulse', t=seconds)
+                    .output(output_filename, format='wav', loglevel='warning',
                             ac=1, ar=48000, sample_fmt='s16')
                     .run(capture_stdout=True, capture_stderr=True)
             )

--- a/birdcage_backend/app/stream_processing.py
+++ b/birdcage_backend/app/stream_processing.py
@@ -435,6 +435,11 @@ def analyze_recordings(self):
 
                     else:
                         print('FAIL')
+                        # 0 bytes from failed ffmpegs causing a loop
+                        if os.stat(file_path).st_size == 0:
+                            os.remove(file_path)
+                            print("Removed " + file_path + " as it was 0 bytes and failed", flush=True)
+
 
             # Clean up recordings once per day.
             if (datetime.now() - last_cleanup_time) > timedelta(days=1):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
                                #to be fancy you can use a device on a remote machine and put its address here. See the wiki
       #SCRIPT_NAME: /birdcage # Uncomment this if you want to reverse proxy to BirdCAGE at a subfolder like /birdcage/
     tmpfs:
-      - /tmp:size=16M #you might want to increase this size if you are recording a bunch of streams, if your
+      - /tmp:size=64M #you might want to increase this size if you are recording a bunch of streams, if your
                       # streams are particularly hi-res, or if your analyzer might be periodically unavailable
     #volumes_from: #uncomment for HA addon 
     #  - container:addon_local_birdcage #uncomment for HA addon 


### PR DESCRIPTION
After analyzing failure scenarios on my own low end cameras using neolink, wyze bridge and go2rtc on frigate I came to these changes.

One issue may be it just hangs on connecting or disconnecting the socket, I could not find the socket timeout option in the python-ffmpeg library so I wrapped it in some process timeout to keep moving, this may end up with 20 dead processes each holding the inodes on the deleted wav file, so the tmp needed to be bigger to accommodate. 

I hit a scenario where it outputted FAIL and looped with a 0 byte file so added a delete there.

Hope this helps anyone. 